### PR TITLE
#12 +semver: patch AzureTableRepository.TableName was using nameof(TE…

### DIFF
--- a/Ease.Repository.AzureTable.Tests/Data/SampleAzureTableRepositoryTests.cs
+++ b/Ease.Repository.AzureTable.Tests/Data/SampleAzureTableRepositoryTests.cs
@@ -102,5 +102,28 @@ namespace Ease.Repository.AzureTable.Tests.Data
         {
             return Delete_By_Key_And_Get_RoundTrip_Impl();
         }
+
+        private class Bug_12_Repository : AzureTableRepository<AzureTableRepositoryContext, SampleAzureTableEntity>
+        {
+            public string TheTableName => TableName;
+
+            public Bug_12_Repository(BestEffortUnitOfWork<AzureTableRepositoryContext> unitOfWork) : base(unitOfWork) { }
+
+            protected override string CalculatePartitionKeyFor(SampleAzureTableEntity entity)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Test]
+        public void Bug_12_Default_Table_Name_Should_Be_TypeOf_Entity_Name()
+        {
+            // Arrange
+            var sut = TheFixture.Freeze<Bug_12_Repository>();
+
+            // Act
+            // Assert
+            sut.TheTableName.Should().Be(typeof(SampleAzureTableEntity).Name);
+        }
     }
 }

--- a/Ease.Repository.AzureTable/AzureTableRepository.cs
+++ b/Ease.Repository.AzureTable/AzureTableRepository.cs
@@ -57,12 +57,12 @@ namespace Ease.Repository.AzureTable
         }
 
         /// <summary>
-        /// By default, TableName will be the `nameof(TEntity)` (which means the table name will change if you rename
+        /// By default, TableName will be the `typeof(TEntity).Name` (which means the table name will change if you rename
         /// the entity class). If you wish to have a stable name, then override and return the desired name.
         /// Either way, the actual table name may include a prefix as governed by the `TContext` when it prepares the
         /// table.
         /// </summary>
-        protected virtual string TableName => nameof(TEntity);
+        protected virtual string TableName => typeof(TEntity).Name;
 
         /// <summary>
         /// Override to return a suitable `PartitionKey` derived from the entity. This should be a function of


### PR DESCRIPTION
…ntity) instead of typeof(TEntity).Name